### PR TITLE
Fix for time field with optional milliseconds

### DIFF
--- a/src/GPX.jl
+++ b/src/GPX.jl
@@ -329,7 +329,15 @@ function _parse_gpx(xdoc::XMLDocument)
                             for x_track_point in child_elements(x_track_segment)
                                 if name(x_track_point) == "time"
                                     s = content(x_track_point)
-                                    dt = parse(ZonedDateTime, s, dateformat"yyyy-mm-ddTHH:MM:SSzzz")
+                                    # Required for optional millisecond field
+                                    # see https://github.com/JuliaTime/TimeZones.jl/issues/83
+                                    # Check for period ('.') as indication of
+                                    # datetime format
+                                    dt = if occursin('.', s)
+                                        parse(ZonedDateTime, s, dateformat"yyyy-mm-ddTHH:MM:SS.ssszzz")
+                                    else
+                                        parse(ZonedDateTime, s, dateformat"yyyy-mm-ddTHH:MM:SSzzz")
+                                    end
                                 elseif name(x_track_point) == "ele"
                                     s = content(x_track_point)
                                     ele = parse(Float64, s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ Cap : 314°
 			</trkpt>
 			<trkpt lat="46.58653100" lon="0.30869000">
 				<ele>64.8000</ele>
-				<time>2019-11-07T08:44:55Z</time>
+				<time>2019-11-07T08:44:55.000Z</time>
 				<desc>Vitesse : 11 kts
 Altitude : 213 ft
 Latitude : 46.586531


### PR DESCRIPTION
This fixes #7 by implementing the millisecond format code. The fix checks for if a period('.') is present within the string, to be parsed, if so the parser includes the millisecond format code (`.sss), else reverts to the old `dateformat`. 